### PR TITLE
Add profile and password change templates with basic tests

### DIFF
--- a/app/templates/auth/change_password.html
+++ b/app/templates/auth/change_password.html
@@ -1,0 +1,58 @@
+{% extends 'layout.html' %}
+
+{% block content %}
+<div class="row justify-content-center">
+    <div class="col-md-8 col-lg-5">
+        <div class="card shadow">
+            <div class="card-header bg-primary text-white">
+                <h4 class="mb-0"><i class="fas fa-key me-2"></i>Zmiana hasła</h4>
+            </div>
+            <div class="card-body">
+                <form method="POST" action="{{ url_for('auth.change_password') }}">
+                    {{ form.hidden_tag() }}
+
+                    <div class="mb-3">
+                        {{ form.current_password.label(class="form-label") }}
+                        {{ form.current_password(class="form-control", placeholder="Aktualne hasło") }}
+                        {% if form.current_password.errors %}
+                            <div class="invalid-feedback d-block">
+                                {% for error in form.current_password.errors %}
+                                    {{ error }}
+                                {% endfor %}
+                            </div>
+                        {% endif %}
+                    </div>
+
+                    <div class="mb-3">
+                        {{ form.new_password.label(class="form-label") }}
+                        {{ form.new_password(class="form-control", placeholder="Nowe hasło") }}
+                        {% if form.new_password.errors %}
+                            <div class="invalid-feedback d-block">
+                                {% for error in form.new_password.errors %}
+                                    {{ error }}
+                                {% endfor %}
+                            </div>
+                        {% endif %}
+                    </div>
+
+                    <div class="mb-3">
+                        {{ form.new_password2.label(class="form-label") }}
+                        {{ form.new_password2(class="form-control", placeholder="Powtórz nowe hasło") }}
+                        {% if form.new_password2.errors %}
+                            <div class="invalid-feedback d-block">
+                                {% for error in form.new_password2.errors %}
+                                    {{ error }}
+                                {% endfor %}
+                            </div>
+                        {% endif %}
+                    </div>
+
+                    <div class="d-grid">
+                        {{ form.submit(class="btn btn-primary") }}
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/app/templates/auth/profile.html
+++ b/app/templates/auth/profile.html
@@ -1,0 +1,46 @@
+{% extends 'layout.html' %}
+
+{% block content %}
+<div class="row justify-content-center">
+    <div class="col-md-8 col-lg-6">
+        <div class="card shadow">
+            <div class="card-header bg-primary text-white">
+                <h4 class="mb-0"><i class="fas fa-user-cog me-2"></i>Mój profil</h4>
+            </div>
+            <div class="card-body">
+                <form method="POST" action="{{ url_for('auth.profile') }}">
+                    {{ form.hidden_tag() }}
+
+                    <div class="mb-3">
+                        {{ form.first_name.label(class="form-label") }}
+                        {{ form.first_name(class="form-control", placeholder="Imię") }}
+                        {% if form.first_name.errors %}
+                            <div class="invalid-feedback d-block">
+                                {% for error in form.first_name.errors %}
+                                    {{ error }}
+                                {% endfor %}
+                            </div>
+                        {% endif %}
+                    </div>
+
+                    <div class="mb-3">
+                        {{ form.last_name.label(class="form-label") }}
+                        {{ form.last_name(class="form-control", placeholder="Nazwisko") }}
+                        {% if form.last_name.errors %}
+                            <div class="invalid-feedback d-block">
+                                {% for error in form.last_name.errors %}
+                                    {{ error }}
+                                {% endfor %}
+                            </div>
+                        {% endif %}
+                    </div>
+
+                    <div class="d-grid">
+                        {{ form.submit(class="btn btn-primary") }}
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,49 @@
+import os
+import sys
+
+import pytest
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from app import create_app, db
+from app.models import User
+
+
+@pytest.fixture
+def app():
+    app = create_app('app.config.TestingConfig')
+
+    with app.app_context():
+        db.create_all()
+        yield app
+        db.session.remove()
+        db.drop_all()
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+@pytest.fixture
+def user(app):
+    user = User(
+        email='jan.kowalski@example.com',
+        password='bezpiecznehaslo',
+        first_name='Jan',
+        last_name='Kowalski'
+    )
+    db.session.add(user)
+    db.session.commit()
+    return user
+
+
+@pytest.fixture
+def authenticated_client(client, user):
+    login_response = client.post(
+        '/auth/login',
+        data={'email': user.email, 'password': 'bezpiecznehaslo'},
+        follow_redirects=True
+    )
+    assert login_response.status_code == 200
+    return client

--- a/tests/test_auth_views.py
+++ b/tests/test_auth_views.py
@@ -1,0 +1,20 @@
+
+def test_profile_view_renders_form(authenticated_client):
+    response = authenticated_client.get('/auth/profile')
+    assert response.status_code == 200
+
+    html = response.data.decode('utf-8')
+    assert 'name="first_name"' in html
+    assert 'name="last_name"' in html
+    assert 'type="submit"' in html
+
+
+def test_change_password_view_renders_form(authenticated_client):
+    response = authenticated_client.get('/auth/change-password')
+    assert response.status_code == 200
+
+    html = response.data.decode('utf-8')
+    assert 'name="current_password"' in html
+    assert 'name="new_password"' in html
+    assert 'name="new_password2"' in html
+    assert 'type="submit"' in html


### PR DESCRIPTION
## Summary
- add dedicated templates for the profile and password change pages with full form rendering and validation feedback
- introduce pytest fixtures and view tests to ensure the authenticated routes return the expected form fields

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d97e7a36988333998185e95a7989d4