### PR TITLE
Fix transaction balance handling and add tests

### DIFF
--- a/app/models/transaction.py
+++ b/app/models/transaction.py
@@ -9,6 +9,12 @@ class TransactionType(Enum):
     RECEIVED_FROM = 3  # Otrzymałem spłatę od
     REPAID_TO = 4      # Oddałem komuś
 
+    def balance_multiplier(self):
+        """Zwraca mnożnik wykorzystywany przy obliczaniu salda."""
+        if self in (TransactionType.LENT_TO, TransactionType.REPAID_TO):
+            return 1
+        return -1
+
 class Transaction(db.Model):
     __tablename__ = 'transactions'
 
@@ -40,13 +46,8 @@ class Transaction(db.Model):
         
         balance = 0
         for transaction in transactions:
-            if transaction.transaction_type == TransactionType.LENT_TO:
-                # Pożyczyłem komuś (+)
-                balance += float(transaction.amount)
-            elif transaction.transaction_type == TransactionType.RECEIVED_FROM:
-                # Otrzymałem spłatę (-)
-                balance -= float(transaction.amount)
-        
+            balance += float(transaction.amount) * transaction.transaction_type.balance_multiplier()
+
         return balance
 
     @staticmethod

--- a/app/models/transaction.py
+++ b/app/models/transaction.py
@@ -1,7 +1,9 @@
 # app/models/transaction.py
 from datetime import datetime
-from app import db
+from decimal import Decimal
 from enum import Enum
+
+from app import db
 
 class TransactionType(Enum):
     BORROWED_FROM = 1  # Pożyczyłem od (ktoś pożyczył mi)
@@ -9,11 +11,12 @@ class TransactionType(Enum):
     RECEIVED_FROM = 3  # Otrzymałem spłatę od
     REPAID_TO = 4      # Oddałem komuś
 
+    @property
     def balance_multiplier(self):
         """Zwraca mnożnik wykorzystywany przy obliczaniu salda."""
         if self in (TransactionType.LENT_TO, TransactionType.REPAID_TO):
-            return 1
-        return -1
+            return Decimal(1)
+        return Decimal(-1)
 
 class Transaction(db.Model):
     __tablename__ = 'transactions'
@@ -44,9 +47,9 @@ class Transaction(db.Model):
         """
         transactions = Transaction.query.filter_by(user_id=user_id, contact_id=contact_id).all()
         
-        balance = 0
+        balance = Decimal("0")
         for transaction in transactions:
-            balance += float(transaction.amount) * transaction.transaction_type.balance_multiplier()
+            balance += transaction.amount * transaction.transaction_type.balance_multiplier
 
         return balance
 

--- a/tests/test_transaction_balance.py
+++ b/tests/test_transaction_balance.py
@@ -1,0 +1,66 @@
+import os
+import sys
+from decimal import Decimal
+
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from app import create_app, db
+from app.models.contact import Contact
+from app.models.transaction import Transaction, TransactionType
+from app.models.user import User
+
+
+@pytest.fixture
+def app_context():
+    app = create_app('app.config.TestingConfig')
+    with app.app_context():
+        db.create_all()
+        yield app
+        db.session.remove()
+        db.drop_all()
+
+
+def test_balance_with_all_transaction_types(app_context):
+    user = User(email='john@example.com', password='secret', first_name='John', last_name='Doe')
+    contact = Contact(user=user, name='Jane Doe')
+
+    db.session.add(user)
+    db.session.add(contact)
+    db.session.commit()
+
+    transactions = [
+        Transaction(
+            user_id=user.id,
+            contact_id=contact.id,
+            amount=Decimal('100.00'),
+            transaction_type=TransactionType.LENT_TO,
+        ),
+        Transaction(
+            user_id=user.id,
+            contact_id=contact.id,
+            amount=Decimal('50.00'),
+            transaction_type=TransactionType.BORROWED_FROM,
+        ),
+        Transaction(
+            user_id=user.id,
+            contact_id=contact.id,
+            amount=Decimal('30.00'),
+            transaction_type=TransactionType.RECEIVED_FROM,
+        ),
+        Transaction(
+            user_id=user.id,
+            contact_id=contact.id,
+            amount=Decimal('20.00'),
+            transaction_type=TransactionType.REPAID_TO,
+        ),
+    ]
+
+    db.session.add_all(transactions)
+    db.session.commit()
+
+    expected_balance = 40.0
+
+    assert Transaction.get_balance_with_contact(user.id, contact.id) == pytest.approx(expected_balance)
+    assert contact.get_balance() == pytest.approx(expected_balance)

--- a/tests/test_transaction_balance.py
+++ b/tests/test_transaction_balance.py
@@ -60,7 +60,7 @@ def test_balance_with_all_transaction_types(app_context):
     db.session.add_all(transactions)
     db.session.commit()
 
-    expected_balance = 40.0
+    expected_balance = Decimal('40.00')
 
-    assert Transaction.get_balance_with_contact(user.id, contact.id) == pytest.approx(expected_balance)
-    assert contact.get_balance() == pytest.approx(expected_balance)
+    assert Transaction.get_balance_with_contact(user.id, contact.id) == expected_balance
+    assert contact.get_balance() == expected_balance


### PR DESCRIPTION
## Summary
- adjust transaction balance calculation to account for all transaction types
- expose a balance multiplier helper on the transaction type enum
- add a unit test covering the combined balance scenario across all transaction types

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d985227a708333aaecae185247947d