### PR TITLE
Fix transaction type selection to match enum values

### DIFF
--- a/app/routes/transaction.py
+++ b/app/routes/transaction.py
@@ -41,10 +41,11 @@ def new(contact_id):
         return redirect(url_for('contact.view', id=contact.id))
     
     return render_template(
-        'transaction/form.html', 
-        form=form, 
-        contact=contact, 
-        title='Nowa transakcja'
+        'transaction/form.html',
+        form=form,
+        contact=contact,
+        title='Nowa transakcja',
+        TransactionType=TransactionType
     )
 
 @transaction_bp.route('/<int:id>/edit', methods=['GET', 'POST'])
@@ -74,10 +75,11 @@ def edit(id):
         return redirect(url_for('contact.view', id=transaction.contact_id))
     
     return render_template(
-        'transaction/form.html', 
-        form=form, 
-        contact=transaction.contact, 
-        title='Edytuj transakcję'
+        'transaction/form.html',
+        form=form,
+        contact=transaction.contact,
+        title='Edytuj transakcję',
+        TransactionType=TransactionType
     )
 
 @transaction_bp.route('/<int:id>/delete', methods=['POST'])

--- a/app/templates/transaction/form.html
+++ b/app/templates/transaction/form.html
@@ -45,34 +45,34 @@
               <label class="form-label fw-semibold">{{ form.transaction_type.label }}</label>
               <div class="row g-3">
                 {% for value, label in form.transaction_type.choices %}
+                {% if value == TransactionType.LENT_TO.value %}
+                  {% set icon_class = 'fas fa-arrow-right text-primary' %}
+                  {% set bg_style = 'rgba(25, 135, 84, 0.1)' %}
+                {% elif value == TransactionType.BORROWED_FROM.value %}
+                  {% set icon_class = 'fas fa-arrow-left text-info' %}
+                  {% set bg_style = 'rgba(13, 110, 253, 0.1)' %}
+                {% elif value == TransactionType.RECEIVED_FROM.value %}
+                  {% set icon_class = 'fas fa-arrow-left text-success' %}
+                  {% set bg_style = 'rgba(25, 135, 84, 0.1)' %}
+                {% elif value == TransactionType.REPAID_TO.value %}
+                  {% set icon_class = 'fas fa-arrow-right text-danger' %}
+                  {% set bg_style = 'rgba(220, 53, 69, 0.1)' %}
+                {% else %}
+                  {% set icon_class = 'fas fa-exchange-alt text-primary' %}
+                  {% set bg_style = 'rgba(78, 115, 223, 0.1)' %}
+                {% endif %}
                 <div class="col-md-3 col-6">
                   <div class="form-check transaction-type-card">
-                    <input class="form-check-input" type="radio" name="{{ form.transaction_type.name }}" 
-                           id="transaction_type_{{ value }}" value="{{ value }}" 
+                    <input class="form-check-input" type="radio" name="{{ form.transaction_type.name }}"
+                           id="transaction_type_{{ value }}" value="{{ value }}"
                            {% if form.transaction_type.data == value %}checked{% endif %}>
-                    <label class="form-check-label transaction-type-label rounded-4 p-3 text-center w-100" 
+                    <label class="form-check-label transaction-type-label rounded-4 p-3 text-center w-100"
                            for="transaction_type_{{ value }}">
-                      {% if value == 1 %} <!-- LENT_TO -->
-                      <div class="transaction-icon-bg d-inline-block rounded-circle mb-2" style="width: 48px; height: 48px; line-height: 48px; background: rgba(25, 135, 84, 0.1);">
-                        <i class="fas fa-arrow-right text-primary"></i>
+                      <div class="transaction-icon-bg d-inline-block rounded-circle mb-2"
+                           style="width: 48px; height: 48px; line-height: 48px; background: {{ bg_style }};">
+                        <i class="{{ icon_class }}"></i>
                       </div>
-                      <div class="fw-semibold">Pożyczyłem</div>
-                      {% elif value == 2 %} <!-- BORROWED_FROM -->
-                      <div class="transaction-icon-bg d-inline-block rounded-circle mb-2" style="width: 48px; height: 48px; line-height: 48px; background: rgba(13, 110, 253, 0.1);">
-                        <i class="fas fa-arrow-left text-info"></i>
-                      </div>
-                      <div class="fw-semibold">Pożyczył mi</div>
-                      {% elif value == 3 %} <!-- RECEIVED_FROM -->
-                      <div class="transaction-icon-bg d-inline-block rounded-circle mb-2" style="width: 48px; height: 48px; line-height: 48px; background: rgba(25, 135, 84, 0.1);">
-                        <i class="fas fa-arrow-left text-success"></i>
-                      </div>
-                      <div class="fw-semibold">Oddał mi</div>
-                      {% elif value == 4 %} <!-- REPAID_TO -->
-                      <div class="transaction-icon-bg d-inline-block rounded-circle mb-2" style="width: 48px; height: 48px; line-height: 48px; background: rgba(220, 53, 69, 0.1);">
-                        <i class="fas fa-arrow-right text-danger"></i>
-                      </div>
-                      <div class="fw-semibold">Oddałem</div>
-                      {% endif %}
+                      <div class="fw-semibold">{{ label }}</div>
                     </label>
                   </div>
                 </div>


### PR DESCRIPTION
## Summary
- expose TransactionType enum to the transaction form template
- update the radio button rendering to rely on enum values and provided labels
- ensure transaction selection matches the enum used in history view

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d99082fb848333a1182d24f490f7e6